### PR TITLE
Change the logo to link to the LMS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Environment Variables
 
 This component requires that the following environment variable be set by the consuming micro-frontend.
 
+* ``LMS_BASE_URL`` - The URL of the LMS of your Open edX instance.
 * ``LOGO_TRADEMARK_URL`` - This is a URL to a logo for use in the footer.  This is a different environment variable than ``LOGO_URL`` (used in frontend-component-header) to accommodate sites that would like to have additional trademark information on a logo in the footer, such as a (tm) or (r) symbol.
 
 ************

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -9,6 +9,7 @@ import messages from './Footer.messages';
 import LanguageSelector from './LanguageSelector';
 
 ensureConfig([
+  'LMS_BASE_URL',
   'LOGO_TRADEMARK_URL',
 ], 'Footer component');
 
@@ -58,7 +59,7 @@ class SiteFooter extends React.Component {
         <div className="container-fluid d-flex">
           <a
             className="d-block"
-            href="https://open.edx.org"
+            href={config.LMS_BASE_URL}
             aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
           >
             <img

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -17,6 +17,7 @@ describe('<Footer />', () => {
                 authenticatedUser: null,
                 config: {
                   LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
+                  LMS_BASE_URL: process.env.LMS_BASE_URL,
                 },
               }}
             >
@@ -36,6 +37,7 @@ describe('<Footer />', () => {
                 authenticatedUser: null,
                 config: {
                   LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
+                  LMS_BASE_URL: process.env.LMS_BASE_URL,
                 },
               }}
             >
@@ -55,6 +57,7 @@ describe('<Footer />', () => {
                 authenticatedUser: null,
                 config: {
                   LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
+                  LMS_BASE_URL: process.env.LMS_BASE_URL,
                 },
               }}
             >
@@ -83,6 +86,7 @@ describe('<Footer />', () => {
               authenticatedUser: null,
               config: {
                 LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
+                LMS_BASE_URL: process.env.LMS_BASE_URL,
               },
             }}
           >

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
     <a
       aria-label="edX Home"
       className="d-block"
-      href="https://open.edx.org"
+      href="http://localhost:18000"
     >
       <img
         alt="Powered by Open edX"
@@ -83,7 +83,7 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
     <a
       aria-label="edX Home"
       className="d-block"
-      href="https://open.edx.org"
+      href="http://localhost:18000"
     >
       <img
         alt="Powered by Open edX"
@@ -113,7 +113,7 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
     <a
       aria-label="edX Home"
       className="d-block"
-      href="https://open.edx.org"
+      href="http://localhost:18000"
     >
       <img
         alt="Powered by Open edX"


### PR DESCRIPTION
# Description

Changed the hard-coded link of the Logo to the LMS_BASE_URL config variable, since it is required for Open edX micro-frontends and it points to the fully-qualified URL to the LMS.

Also, changed the README.rst to include the environment variable LMS_BASE_URL as required.

# Useful information to include:

Related issue: https://github.com/openedx/build-test-release-wg/issues/128

# Testing instructions

I tested using the [frontend-template-application](https://github.com/openedx/frontend-template-application) and used the "module.config.js" file to [override](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack) the frontend-component-footer with my local module.

Then, I just ran my template and clicked on the logo that is located in the bottom left corner and checked that it is not redirected to: "https://open.edx.org/". Now, the link is to the LMS.
