### PR TITLE
feat: upgrade to React 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       "peerDependencies": {
         "@edx/frontend-platform": "^2.3.0",
         "prop-types": "^15.5.10",
-        "react": "^16.9.0",
+        "react": "^17.0.0",
         "react-dom": "^16.9.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "@edx/frontend-platform": "^2.3.0",
     "prop-types": "^15.5.10",
-    "react": "^16.9.0",
+    "react": "^17.0.0",
     "react-dom": "^16.9.0"
   }
 }


### PR DESCRIPTION
In order to get tests to pass in the https://github.com/openedx/frontend-app-library-authoring/tree/9c2ec1edab14ed1cd1970f858c22dd30f58903f5 Repo, we need to upgrade the footer to use react 17.