### PR TITLE
fix: frontend platform peer dependency to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@fortawesome/react-fontawesome": "0.2.0"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^2.3.0",
+    "@edx/frontend-platform": "^3.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Peer dependency was not updated when updating the frontend platform version