### PR TITLE
Update transifex api from v2 to v3 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export TRANSIFEX_RESOURCE = frontend-component-footer
-transifex_resource = frontend-component-footer
 transifex_langs = "ar,fr,es_419,zh_CN,pt,it,de,uk,ru,hi,fr_CA"
 
 transifex_utils = ./node_modules/.bin/transifex-utils.js

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
+export TRANSIFEX_RESOURCE = frontend-component-footer
 transifex_resource = frontend-component-footer
 transifex_langs = "ar,fr,es_419,zh_CN,pt,it,de,uk,ru,hi,fr_CA"
 
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
-tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/translation/en/strings/
-tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/source/
 
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
@@ -42,11 +41,11 @@ push_translations:
 	# Pushing strings to Transifex...
 	tx push -s
 	# Fetching hashes from Transifex...
-	./node_modules/reactifex/bash_scripts/get_hashed_strings.sh $(tx_url1)
+	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
 	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments
+	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
 	# Pushing comments to Transifex...
-	./node_modules/reactifex/bash_scripts/put_comments.sh $(tx_url2)
+	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
 # Pulls translations from Transifex.
 pull_translations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@edx/frontend-build": "12.4.19",
         "@edx/frontend-platform": "^3.0.1",
         "@edx/paragon": "^20.19.0",
+        "@edx/reactifex": "^2.1.1",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.7",
         "husky": "8.0.3",
@@ -30,7 +31,6 @@
         "react-redux": "7.2.9",
         "react-router-dom": "5.3.4",
         "react-test-renderer": "16.14.0",
-        "reactifex": "1.1.1",
         "redux": "4.2.1",
         "semantic-release": "19.0.5"
       },
@@ -2178,6 +2178,69 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@edx/reactifex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.1.1.tgz",
+      "integrity": "sha512-A/DfCPsNNRuWhhWCquInlfG6Pi//qcxAi0P2jY/UeOVAHoOLkA3L328UtHEuoZbncXT2E1H1EDlpfNrovo/nng==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.21.1",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "edx_reactifex": "main.js"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -20306,15 +20369,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true,
-      "bin": {
-        "reactifex": "main.js"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -26562,6 +26616,59 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
+        }
+      }
+    },
+    "@edx/reactifex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.1.1.tgz",
+      "integrity": "sha512-A/DfCPsNNRuWhhWCquInlfG6Pi//qcxAi0P2jY/UeOVAHoOLkA3L328UtHEuoZbncXT2E1H1EDlpfNrovo/nng==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
         }
       }
     },
@@ -40117,12 +40224,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
-    },
-    "reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@edx/frontend-build": "12.4.19",
     "@edx/frontend-platform": "^3.0.1",
     "@edx/paragon": "^20.19.0",
+    "@edx/reactifex": "^2.1.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.7",
     "husky": "8.0.3",
@@ -47,7 +48,6 @@
     "react-redux": "7.2.9",
     "react-router-dom": "5.3.4",
     "react-test-renderer": "16.14.0",
-    "reactifex": "1.1.1",
     "redux": "4.2.1",
     "semantic-release": "19.0.5"
   },


### PR DESCRIPTION
**Ticket**
[Updating /api/v2 transifex endpoints](https://github.com/edx/edx-arch-experiments/issues/202)

**What has changed?**
- Update Makefile commands for new v3 transifex API
- Add edx/reactifex as dependency

**Reference PR**
https://github.com/openedx/frontend-app-learning/pull/837