### PR TITLE
chore: resolve http-cache-semantics security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16277,7 +16277,7 @@
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
@@ -16691,7 +16691,7 @@
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
+        "http-cache-semantics": "^4.1.1",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",


### PR DESCRIPTION
This PR resolves the security vulnerability related to [http-cache-semantics](https://github.com/openedx/frontend-component-footer/security/dependabot/67).