### PR TITLE
feat: configure style via MFE config api

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,3 +17,4 @@ LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
 LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
 LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg
 FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
+MFE_CONFIG_API_URL=http://localhost:18000/api/mfe_config/v1

--- a/README.rst
+++ b/README.rst
@@ -51,22 +51,58 @@ This library has the following exports:
   language from its dropdown.
 * supportedLanguages: An array of objects representing available languages.  See example below for object shape.
 
+Customization via MFE config API
+================================
+
+Other than the environment variables listed above, it is also possible to customize the footer via `MFE config API <https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/mfe_config_api/docs/decisions/0001-mfe-config-api.rst>`_. Below is the possible list of settings
+
+.. code-block:: python
+
+   MFE_CONFIG = {
+       # Update footer container styling
+       "FOOTER_CUSTOM_STYLE": {
+           "backgroundImage": "url(http://<some-image-url>)",
+           # to change opacity of background image
+           # "backgroundImage": "linear-gradient( rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85) ) , url(http://<some-image-url>)",
+       },
+       # Update footer container styling via bootstrap classes
+       "FOOTER_CUSTOM_CLASSNAMES": "py-5 px-4 text-center flex-column justify-content-center flex-wrap text-dark",
+       # Update footer logo styling
+       "FOOTER_LOGO_STYLE": {
+           "marginBottom": "2rem",
+       },
+       # Override environment variable
+       "LOGO_TRADEMARK_URL": "https://<logo url>",
+       # Add links to footer
+       "FOOTER_LINKS": [
+           {"url": "https://openedx.org/terms-of-use/", "text": "Terms of service"},
+           {"url": "https://openedx.org/code-of-conduct/", "text": "Code of conduct"},
+           {"url": "https://openedx.org/privacy-policy/", "text": "Privacy Policy"},
+       ],
+       # Update link container classes
+       "FOOTER_LINKS_CONTAINER_CLASSNAMES": "flex-wrap",
+       # Update link styling
+       "FOOTER_LINKS_CLASSNAMES": "text-dark font-weight-bold",
+   }
+
 Examples
 ========
 
-Component Usage Example::
+Component Usage Example
 
-  import Footer, { messages } from '@edx/frontend-component-footer';
+.. code-block:: javascript
 
-  ...
+   import Footer, { messages } from '@edx/frontend-component-footer';
 
-  <Footer
-    onLanguageSelected={(languageCode) => {/* set language */}}
-    supportedLanguages={[
-      { label: 'English', value: 'en'},
-      { label: 'Español', value: 'es' },
-    ]}
-  />
+   ...
+
+   <Footer
+     onLanguageSelected={(languageCode) => {/* set language */}}
+     supportedLanguages={[
+       { label: 'English', value: 'en'},
+       { label: 'Español', value: 'es' },
+     ]}
+   />
 
 * `An example of minimal component and messages usage. <https://github.com/openedx/frontend-template-application/blob/3355bb3a96232390e9056f35b06ffa8f105ed7ca/src/index.jsx#L23>`_
 * `An example of SCSS file usage. <https://github.com/openedx/frontend-template-application/blob/3cd5485bf387b8c479baf6b02bf59e3061dc3465/src/index.scss#L9>`_

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -42,32 +42,45 @@ class SiteFooter extends React.Component {
     } = this.props;
     const showLanguageSelector = supportedLanguages.length > 0 && onLanguageSelected;
     const { config } = this.context;
-
     return (
       <footer
         role="contentinfo"
-        className="footer d-flex border-top py-3 px-4"
+        className={`footer d-flex border-top py-3 px-4 ${config.FOOTER_CUSTOM_CLASSNAMES || ''}`}
+        style={config.FOOTER_CUSTOM_STYLE}
       >
-        <div className="container-fluid d-flex">
-          <a
-            className="d-block"
-            href={config.LMS_BASE_URL}
-            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-          >
-            <img
-              style={{ maxHeight: 45 }}
-              src={logo || config.LOGO_TRADEMARK_URL}
-              alt={intl.formatMessage(messages['footer.logo.altText'])}
-            />
-          </a>
-          <div className="flex-grow-1" />
-          {showLanguageSelector && (
-            <LanguageSelector
-              options={supportedLanguages}
-              onSubmit={onLanguageSelected}
-            />
-          )}
-        </div>
+        <a
+          className="d-block"
+          href={config.LMS_BASE_URL}
+          aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+        >
+          <img
+            style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
+            src={logo || config.LOGO_TRADEMARK_URL}
+            alt={intl.formatMessage(messages['footer.logo.altText'])}
+          />
+        </a>
+        <div className="flex-grow-1" />
+        {Array.isArray(config.FOOTER_LINKS) && (
+          <div className={`d-flex align-items-center justify-content-center ${config.FOOTER_LINKS_CONTAINER_CLASSNAMES || ''}`}>
+            {config.FOOTER_LINKS.map(element => (
+              <a
+                key={element.url}
+                className={`px-3 ${config.FOOTER_LINKS_CLASSNAMES}`}
+                href={element.url}
+                target={element.target || 'blank'}
+              >
+                {element.text}
+              </a>
+            )).reduce((prev, curr) => [prev, '|', curr])}
+          </div>
+        )}
+        {showLanguageSelector && (
+          <LanguageSelector
+            options={supportedLanguages}
+            onSubmit={onLanguageSelected}
+          />
+        )}
+
       </footer>
     );
   }

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -13,6 +13,16 @@ const FooterWithContext = ({ locale = 'es' }) => {
     config: {
       LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
       LMS_BASE_URL: process.env.LMS_BASE_URL,
+      FOOTER_CUSTOM_STYLE: { color: 'black' },
+      FOOTER_CUSTOM_CLASSNAMES: 'text-center',
+      FOOTER_LOGO_STYLE: { color: 'white' },
+      FOOTER_LINKS: [
+        { url: 'https://openedx.org/terms-of-use/', text: 'Terms of service' },
+        { url: 'https://openedx.org/code-of-conduct/', text: 'Code of conduct' },
+        { url: 'https://openedx.org/privacy-policy/', text: 'Privacy Policy' },
+      ],
+      FOOTER_LINKS_CONTAINER_CLASSNAMES: 'flex-wrap',
+      FOOTER_LINKS_CLASSNAMES: 'text-dark font-weight-bold',
     },
   }), []);
 

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -13,7 +13,7 @@ const LanguageSelector = ({
 
   return (
     <form
-      className="form-inline"
+      className="form-inline justify-content-center"
       onSubmit={handleSubmit}
       {...props}
     >

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -2,128 +2,182 @@
 
 exports[`<Footer /> renders correctly renders with a language selector 1`] = `
 <footer
-  className="footer d-flex border-top py-3 px-4"
+  className="footer d-flex border-top py-3 px-4 "
   role="contentinfo"
 >
-  <div
-    className="container-fluid d-flex"
+  <a
+    aria-label="edX Home"
+    className="d-block"
+    href="http://localhost:18000"
   >
-    <a
-      aria-label="edX Home"
-      className="d-block"
-      href="http://localhost:18000"
-    >
-      <img
-        alt="Powered by Open edX"
-        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-        style={
-          Object {
-            "maxHeight": 45,
-          }
+    <img
+      alt="Powered by Open edX"
+      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+      style={
+        Object {
+          "maxHeight": 45,
         }
-      />
-    </a>
-    <div
-      className="flex-grow-1"
+      }
     />
-    <form
-      className="form-inline"
-      onSubmit={[Function]}
+  </a>
+  <div
+    className="flex-grow-1"
+  />
+  <form
+    className="form-inline justify-content-center"
+    onSubmit={[Function]}
+  >
+    <div
+      className="form-group"
     >
-      <div
-        className="form-group"
+      <label
+        className="d-inline-block m-0"
+        htmlFor="site-footer-language-select"
       >
-        <label
-          className="d-inline-block m-0"
-          htmlFor="site-footer-language-select"
+        Choose Language
+      </label>
+      <select
+        className="form-control-sm mx-2"
+        defaultValue="en"
+        id="site-footer-language-select"
+        name="site-footer-language-select"
+      >
+        <option
+          value="en"
         >
-          Choose Language
-        </label>
-        <select
-          className="form-control-sm mx-2"
-          defaultValue="en"
-          id="site-footer-language-select"
-          name="site-footer-language-select"
+          English
+        </option>
+        <option
+          value="es"
         >
-          <option
-            value="en"
-          >
-            English
-          </option>
-          <option
-            value="es"
-          >
-            Español
-          </option>
-        </select>
-        <button
-          className="btn btn-outline-primary btn-sm"
-          type="submit"
-        >
-          Apply
-        </button>
-      </div>
-    </form>
-  </div>
+          Español
+        </option>
+      </select>
+      <button
+        className="btn btn-outline-primary btn-sm"
+        type="submit"
+      >
+        Apply
+      </button>
+    </div>
+  </form>
 </footer>
 `;
 
 exports[`<Footer /> renders correctly renders without a language selector 1`] = `
 <footer
-  className="footer d-flex border-top py-3 px-4"
+  className="footer d-flex border-top py-3 px-4 text-center"
   role="contentinfo"
+  style={
+    Object {
+      "color": "black",
+    }
+  }
 >
+  <a
+    aria-label="edX Home"
+    className="d-block"
+    href="http://localhost:18000"
+  >
+    <img
+      alt="Powered by Open edX"
+      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+      style={
+        Object {
+          "color": "white",
+          "maxHeight": 45,
+        }
+      }
+    />
+  </a>
   <div
-    className="container-fluid d-flex"
+    className="flex-grow-1"
+  />
+  <div
+    className="d-flex align-items-center justify-content-center flex-wrap"
   >
     <a
-      aria-label="edX Home"
-      className="d-block"
-      href="http://localhost:18000"
+      className="px-3 text-dark font-weight-bold"
+      href="https://openedx.org/terms-of-use/"
+      target="blank"
     >
-      <img
-        alt="Powered by Open edX"
-        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-        style={
-          Object {
-            "maxHeight": 45,
-          }
-        }
-      />
+      Terms of service
     </a>
-    <div
-      className="flex-grow-1"
-    />
+    |
+    <a
+      className="px-3 text-dark font-weight-bold"
+      href="https://openedx.org/code-of-conduct/"
+      target="blank"
+    >
+      Code of conduct
+    </a>
+    |
+    <a
+      className="px-3 text-dark font-weight-bold"
+      href="https://openedx.org/privacy-policy/"
+      target="blank"
+    >
+      Privacy Policy
+    </a>
   </div>
 </footer>
 `;
 
 exports[`<Footer /> renders correctly renders without a language selector in es 1`] = `
 <footer
-  className="footer d-flex border-top py-3 px-4"
+  className="footer d-flex border-top py-3 px-4 text-center"
   role="contentinfo"
+  style={
+    Object {
+      "color": "black",
+    }
+  }
 >
+  <a
+    aria-label="edX Home"
+    className="d-block"
+    href="http://localhost:18000"
+  >
+    <img
+      alt="Powered by Open edX"
+      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+      style={
+        Object {
+          "color": "white",
+          "maxHeight": 45,
+        }
+      }
+    />
+  </a>
   <div
-    className="container-fluid d-flex"
+    className="flex-grow-1"
+  />
+  <div
+    className="d-flex align-items-center justify-content-center flex-wrap"
   >
     <a
-      aria-label="edX Home"
-      className="d-block"
-      href="http://localhost:18000"
+      className="px-3 text-dark font-weight-bold"
+      href="https://openedx.org/terms-of-use/"
+      target="blank"
     >
-      <img
-        alt="Powered by Open edX"
-        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-        style={
-          Object {
-            "maxHeight": 45,
-          }
-        }
-      />
+      Terms of service
     </a>
-    <div
-      className="flex-grow-1"
-    />
+    |
+    <a
+      className="px-3 text-dark font-weight-bold"
+      href="https://openedx.org/code-of-conduct/"
+      target="blank"
+    >
+      Code of conduct
+    </a>
+    |
+    <a
+      className="px-3 text-dark font-weight-bold"
+      href="https://openedx.org/privacy-policy/"
+      target="blank"
+    >
+      Privacy Policy
+    </a>
   </div>
 </footer>
 `;


### PR DESCRIPTION
**Description**

This PR adds functionality to customize the footer using MFE config API to some extent. This allows users to customize the footer per site without creating multiple footer components.

<details>
  <summary>Screenshots</summary>

Default look with no customization:

![image](https://github.com/openedx/frontend-component-footer/assets/10894099/1ae7ac87-c18d-457b-b3b1-7ab33b22d18d)

With MFE config:
```python
MFE_CONFIG = {
    "FOOTER_CUSTOM_STYLE": {
        "backgroundImage": "url(https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTgb0Xw3iHTv4pobzu3cSStIU3txTxzC1LHNw&usqp=CAU)",
        # "backgroundImage": "linear-gradient( rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85) ) , url(https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQRyiCBR1eTfnv5UcqIKmEHZHLLHHQDt6PiZA&usqp=CAU)",
    },
    "FOOTER_CUSTOM_CLASSNAMES": "py-5 px-4 text-center flex-column justify-content-center flex-wrap text-dark",
    "FOOTER_LOGO_STYLE": {
        "marginBottom": "2rem",
    },
    "LOGO_TRADEMARK_URL": "https://lms.oc.eshe.opencraft.hosting/static/default-eshe-theme/images/logo.5a2f93a71b89.png",
    "FOOTER_LINKS": [
        {"url": "https://google.com", "text": "Terms of service"},
        {"url": "https://duckduckgo.com", "text": "Acceptable Use Policy"},
        {"url": "https://openedx.org", "text": "Privacy Policy"},
    ],
    "FOOTER_LINKS_CONTAINER_CLASSNAMES": "flex-wrap",
    "FOOTER_LINKS_CLASSNAMES": "text-dark font-weight-bold",
}
```

And removal of support languages parameter as shown in diff below:

```diff
diff --git a/example/index.jsx b/example/index.jsx
index 580fccc..403c3b2 100644
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -16,11 +16,6 @@ subscribe(APP_READY, () => {
         config: getConfig(),
       }}>
         <Footer
-          onLanguageSelected={() => {}}
-          supportedLanguages={[
-            { label: 'English', value: 'en' },
-            { label: 'Español', value: 'es' },
-          ]}
         />
       </AppContext.Provider>
     </AppProvider>,
```

Results:

![image](https://github.com/openedx/frontend-component-footer/assets/10894099/228b7183-c5e3-4b8e-9501-1813961d8090)

Result with no alignment changes:

![image](https://github.com/openedx/frontend-component-footer/assets/10894099/5342908d-53a1-48da-a86e-618389a43f36)


</details>

**Test instructions:**

* Start lms in master devstack using `make lms-up`.
* Add below settings to `lms/envs/private.py`.
```python
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG = {}
```
* Clone this repo in some location and run `npm install` and `npm run start`.
* Visit http://localhost:8080/ to see default footer.
* Update settings in `lms/envs/private.py` as shown below:
```python
ENABLE_MFE_CONFIG_API = True
MFE_CONFIG_API_CACHE_TIMEOUT = 0
MFE_CONFIG = {
    "FOOTER_CUSTOM_STYLE": {
        "backgroundImage": "url(https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTgb0Xw3iHTv4pobzu3cSStIU3txTxzC1LHNw&usqp=CAU)",
        # "backgroundImage": "linear-gradient( rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85) ) , url(https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQRyiCBR1eTfnv5UcqIKmEHZHLLHHQDt6PiZA&usqp=CAU)",
    },
    "FOOTER_CUSTOM_CLASSNAMES": "py-5 px-4 text-center flex-column justify-content-center flex-wrap text-dark",
    "FOOTER_LOGO_STYLE": {
        "marginBottom": "2rem",
    },
    "LOGO_TRADEMARK_URL": "https://lms.oc.eshe.opencraft.hosting/static/default-eshe-theme/images/logo.5a2f93a71b89.png",
    "FOOTER_LINKS": [
        {"url": "https://google.com", "text": "Terms of service"},
        {"url": "https://duckduckgo.com", "text": "Acceptable Use Policy"},
        {"url": "https://openedx.org", "text": "Privacy Policy"},
    ],
    "FOOTER_LINKS_CLASSNAMES": "text-dark font-weight-bold",
}
```
* [Optional] Remove language switcher from footer by removing below lines from `example/index.jsx`.
```diff
diff --git a/example/index.jsx b/example/index.jsx
index 580fccc..403c3b2 100644
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -16,11 +16,6 @@ subscribe(APP_READY, () => {
         config: getConfig(),
       }}>
         <Footer
-          onLanguageSelected={() => {}}
-          supportedLanguages={[
-            { label: 'English', value: 'en' },
-            { label: 'Español', value: 'es' },
-          ]}
         />
       </AppContext.Provider>
     </AppProvider>,
```
* Visit http://localhost:8080/  again to see customized footer.