### PR TITLE
fix: fix config name from MARKETING_BASE_URL to MARKETING_SITE_BASE_URL

### DIFF
--- a/src/components/studio-footer/StudioFooter.jsx
+++ b/src/components/studio-footer/StudioFooter.jsx
@@ -94,7 +94,7 @@ const StudioFooter = ({
           ) : null}
         </TransitionReplace>
         <ActionRow className="pt-3 m-0 x-small">
-          © {new Date().getFullYear()} <Hyperlink destination={config.MARKETING_BASE_URL} target="_blank" className="ml-2">{config.SITE_NAME}</Hyperlink>
+          © {new Date().getFullYear()} <Hyperlink destination={config.MARKETING_SITE_BASE_URL} target="_blank" className="ml-2">{config.SITE_NAME}</Hyperlink>
           <ActionRow.Spacer />
           {!_.isEmpty(config.TERMS_OF_SERVICE_URL) && (
             <Hyperlink destination={config.TERMS_OF_SERVICE_URL} data-testid="termsOfService">


### PR DESCRIPTION
**Description:**
The config name for the marketing URL is MARKETING_SITE_BASE_URL but MARKETING_BASE_URL is used in the Footer and it is not getting picked up from the config. This PR just fixes the name of the config variable.