### PR TITLE
fix: update frontend-platform peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "semantic-release": "21.1.2"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "@edx/frontend-platform": "^7.0.0",
         "@openedx/paragon": ">= 21.11.3 < 22.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@edx/frontend-platform": "^7.0.0",
     "@openedx/paragon": ">= 21.11.3 < 22.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0 || ^17.0.0",


### PR DESCRIPTION
This updates the `frontend-platform` peer dependency to require a version that has `paragon` in the `openedx` scope as a peer dependency, as opposed to the `edx` scope