### PR TITLE
docs: Document the owner and drop the old metadata file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "frontend-component-footer"
+  description: "A generic footer for the Open edX micro-frontend applications."
+  annotations:
+    openedx.org/arch-interest-groups: ""
+spec:
+  owner: group:committers-frontend
+  type: "library"
+  lifecycle: "production"

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,8 +1,0 @@
-# openedx.yaml
-
----
-owner: edx/fedx-team
-tags:
-  - library
-  - component
-  - react


### PR DESCRIPTION
This is going to be changing soon with the module federation work so I
think it makes sense to be maintained by the committers-frontend group.

I'm also cleaning up the old openedx.yaml file which is obsolete and out
of date while I'm adding the new metadata that should be up-to-date.
