### PR TITLE
docs: Update references to docs.edx.org

### DIFF
--- a/src/components/studio-footer/StudioFooter.jsx
+++ b/src/components/studio-footer/StudioFooter.jsx
@@ -63,12 +63,12 @@ const StudioFooter = ({
           {isOpen ? (
             <ActionRow key="help-link-button-row" className="py-4" data-testid="helpButtonRow">
               <ActionRow.Spacer />
-              <Button as="a" href="https://docs.edx.org/" size="sm">
+              <Button as="a" href="https://docs.openedx.org/" size="sm">
                 <FormattedMessage {...messages.edxDocumentationButtonLabel} />
               </Button>
               <Button
                 as="a"
-                href="https://open.edx.org/"
+                href="https://openedx.org/"
                 size="sm"
                 data-testid="openEdXPortalButton"
               >
@@ -134,7 +134,7 @@ const StudioFooter = ({
           <FormattedMessage {...messages.trademarkMessage} />
           <Hyperlink className="ml-1" destination="https://www.edx.org">edX Inc</Hyperlink>.
           <ActionRow.Spacer />
-          <Hyperlink destination="https://open.edx.org" className="float-right">
+          <Hyperlink destination="https://openedx.org" className="float-right">
             <Image
               width="120px"
               alt="Powered by Open edX"


### PR DESCRIPTION
With the transition to docs.openedx.org, update links to docs.edx.org to the community-supported site.