### PR TITLE
feat: add another `FooterSlot` id alias

### DIFF
--- a/src/plugin-slots/FooterSlot/index.jsx
+++ b/src/plugin-slots/FooterSlot/index.jsx
@@ -3,7 +3,10 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import Footer from '../../components/Footer';
 
 const FooterSlot = () => (
-  <PluginSlot id="org.openedx.frontend.layout.footer.v1" idAliases={['footer_slot']}>
+  <PluginSlot
+    id="org.openedx.frontend.layout.footer.v1"
+    idAliases={['footer_slot', 'footer_plugin_slot']}
+  >
     <Footer />
   </PluginSlot>
 );


### PR DESCRIPTION
As of writing, `frontend-app-learner-record` doesn't use the `FooterSlot` component, and instead [directly wraps the `Footer` component in a `PluginSlot`](https://github.com/openedx/frontend-app-learner-record/blob/48c1255e443202254a8236d982ba7c2a7851e4ac/src/index.jsx#L52-L56)

The `id` used for that slot by `frontend-app-learner-record` is "`footer_plugin_slot`".

By adding "`footer_plugin_slot`" as an `id` alias, updating `frontend-app-learner-record` to use the `FooterSlot` component can be a non-breaking change.