### PR TITLE
test: Remove support for Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 24]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
### **Description**

Complete the upgrade to Node 24 by removing the Node 20 CI check and going back to using .nvmrc as the source of truth for which version to use.

See https://github.com/openedx/frontend-component-footer/issues/542 for further information.